### PR TITLE
Updated SPNs and APNs for Tuenti (Spain)

### DIFF
--- a/prebuilt/common/etc/apns-conf.xml
+++ b/prebuilt/common/etc/apns-conf.xml
@@ -106,7 +106,7 @@
   <apn carrier="Orange MMS" mcc="214" mnc="03" apn="orangemms" proxy="172.22.188.25" port="8080" user="orange" password="orange" mmsc="http://mms.orange.es" mmsproxy="172.22.188.25" mmsport="8080" authtype="2" type="mms" />
   <apn carrier="Yoigo" mcc="214" mnc="04" apn="internet" proxy="010.008.000.036" port="8080" type="default,supl" />
   <apn carrier="Yoigo MMS" mcc="214" mnc="04" apn="mms" mmsc="http://mms" mmsproxy="193.209.134.141" mmsport="80" type="mms" />
-  <apn carrier="Tuenti Internet" mcc="214" mnc="05" apn="tuenti.com" user="tuenti" password="tuenti" type="default,supl" />
+  <apn carrier="Tuenti Internet" mcc="214" mnc="05" apn="tuenti.com" user="tuenti" password="tuenti" type="default,supl,dun" />
   <apn carrier="Tuenti MMS" mcc="214" mnc="05" apn="tuenti.com" user="tuenti" password="tuenti" mmsc="http://tuenti.com" mmsproxy="10.138.255.43" mmsport="8080" type="mms" />
   <apn carrier="INTERNET GPRS" mcc="214" mnc="06" apn="airtelnet.es" user="vodafone" password="vodafone" type="default,supl" />
   <apn carrier="Pepephone Internet" mcc="214" mnc="06" apn="gprsmov.pepephone.com" type="default,supl" />
@@ -119,6 +119,8 @@
   <apn carrier="Simyo ES-MMS" mcc="214" mnc="19" apn="gprs-service.com" mmsc="http://217.18.32.180:8080" mmsproxy="217.18.32.181" mmsport="8080" type="mms" />
   <apn carrier="Jazztel" mcc="214" mnc="21" apn="jazzinternet" type="default,supl" />
   <apn carrier="Jazztel MMS" mcc="214" mnc="21" apn="jazzmms" mmsc="http://jazztelmms.com:8081" mmsproxy="217.18.32.183" mmsport="8081" type="mms" />
+  <apn carrier="Tuenti Internet" mcc="214" mnc="32" apn="tuenti.com" user="tuenti" password="tuenti" type="default,supl,dun" />
+  <apn carrier="Tuenti MMS" mcc="214" mnc="32" apn="tuenti.com" user="tuenti" password="tuenti" mmsc="http://tuenti.com" mmsproxy="10.138.255.43" mmsport="8080" type="mms" />
   <apn carrier="Pannon MMS" mcc="216" mnc="01" apn="mms" mmsc="http://mmsc.pgsm.hu/" mmsproxy="193.225.154.22" mmsport="8080" type="mms" />
   <apn carrier="Pannon" mcc="216" mnc="01" apn="net" type="default,supl" />
   <apn carrier="Telenor Net" mcc="216" mnc="01" apn="net" type="default,supl" />

--- a/prebuilt/common/etc/selective-spn-conf.xml
+++ b/prebuilt/common/etc/selective-spn-conf.xml
@@ -1370,7 +1370,8 @@
   <spnOverride numeric="21409"  spn="Orange" />
   <spnOverride numeric="21419"  spn="Simyo" />
   <spnOverride numeric="21416"  spn="TeleCable" />
-  <spnOverride numeric="21405"  spn="TME" />
+  <spnOverride numeric="21405"  spn="Tuenti" />
+  <spnOverride numeric="21432"  spn="Tuenti" />
   <spnOverride numeric="21401"  spn="Vodafone" />
   <spnOverride numeric="21406"  spn="Vodafone" />
   <spnOverride numeric="21404"  spn="Yoigo" />


### PR DESCRIPTION
Tuenti has got one more MNC since 16 June 2014, MNC "32".
Internet Tuenti APN type has been modified to make WiFi Tethering work properly.
